### PR TITLE
Config validation and param simplification

### DIFF
--- a/pipeline/Snakefile.master
+++ b/pipeline/Snakefile.master
@@ -198,7 +198,7 @@ rule hostremove_hisat2_build:
     log:
         '{sn}/host_removed/hisat2-build.log'
     params:
-        reference = config['hostremove_reference'],
+        reference = config['viral_reference_genome'],
 	genome = '{sn}/host_removed/sars-cov-2'
     shell:
         'hisat2-build {params.reference} {params.genome} >{log} 2>&1'
@@ -322,7 +322,7 @@ rule run_ivar_variants:
     output:
         '{sn}/ivar_variants/ivar_variants.tsv'
     input:
-        reference = config['hostremove_reference'],
+        reference = config['viral_reference_genome'],
         read_bam = '{sn}/host_removed/both_ends_mapped_lsorted.bam'
     params:
         output_prefix = '{sn}/ivar_variants/ivar_variants',
@@ -504,7 +504,7 @@ rule run_quast:
          '{sn}/quast/quast.log'
     params:
          outdir = '{sn}/quast',
-         genome = config['quast_reference_genome'],
-         fcoords = config['quast_feature_coords']
+         genome = config['viral_reference_genome'],
+         fcoords = config['viral_reference_feature_coords']
     shell:
          'quast {input} -r {params.genome} -g {params.fcoords} --output-dir {params.outdir} --threads {threads} >{log}'

--- a/pipeline/Snakefile.master
+++ b/pipeline/Snakefile.master
@@ -1,3 +1,5 @@
+from snakemake.utils import validate
+
 # Note: this workflow uses specialized conda envs, run with 'snakemake --use-conda'.
 
 # TODO: needs final debug iteration, after the dust settles
@@ -7,6 +9,7 @@
 # For an example config file, see pipeline/example_config.yaml in the covid-19-sequencing repo.
 
 configfile: "config.yaml"
+validate(config, 'config.schema.yaml')
 
 sample_names = sorted(config['samples'].keys())
 

--- a/pipeline/config.schema.yaml
+++ b/pipeline/config.schema.yaml
@@ -1,0 +1,66 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+primer_rc: 
+    type: string
+    description: "path to sequencing primer (reverse complement)"
+primer_fw: 
+    type: string
+    description: "path to sequencing primer (forward)"
+trimmomatic_args:
+    type: string
+    description: "args for trimmomatic e.g. 'ILLUMINACLIP:data/NexteraPE-PE.fa:2:30:10 SLIDINGWINDOW:4:20'"
+viral_reference_genome:
+    type: string
+    description: "path to reference fasta for QC, removing non SARS-CoV2 sequences and generating consensus/variants"
+viral_reference_feature_coords: 
+    type: string
+    description: "path to feature coords on reference viral genome for QC"
+breseq_reference:
+    type: string
+    description: "path to enhanced reference gbk with clinical sequences"
+kraken2_db:
+    type: string
+    description: "path to kraken2 database files"
+mpileup_depth:
+    type: int
+    default: 10000
+    description: "mpileup depth to use for ivar/samtools consensus and variant calling"
+ivar_freq_threshold:
+    type: float
+    default: 0.75
+    description: "ivar frequency threshold to build consensus"
+ivar_min_coverage_depth:
+    type: int
+    default: 10
+    description: "minimum coverage depth to call variant"
+ivar_min_freq_threshold:
+    type: float
+    default: 0.25
+    description: "ivar frequency threshold to call variant (ivar variants: -t )"
+ivar_min_variant_quality:
+    type: int
+    default: 20
+    description: "iVar minimum mapQ to call variant (ivar variants: -q)"
+lmat_fragment_size:
+    type: int
+    default: 250
+    description: "size of fragments (in bp) analyzed by 'lmat'"
+lmat_basedir:
+    type: string
+    description: "absolute pathname of the LMAT DB is {lmat_basedir}/data/{lmat_db}."
+lmat_db:
+    type: string
+    default: 'kML+Human.v4-14.20.g10.db'
+    description: "LMAT database to use"
+samples:
+    type: string
+    description: "Sample filepaths/table"
+required:
+    - primer_rc
+    - primer_fw
+    - trimmomatic_args
+    - viral_reference_genome
+    - viral_reference_feature_coords
+    - breseq_reference
+    - kraken2_db
+    - lmat_basedir
+    - samples

--- a/pipeline/example_config.yaml
+++ b/pipeline/example_config.yaml
@@ -12,7 +12,9 @@ trimmomatic_args: 'ILLUMINACLIP:/home/kmsmith/data/NexteraPE-PE.fa:2:30:10 SLIDI
 
 # Used as hisat2 reference genome when removing host sequences.
 # Also used as 'ivar' reference genome in variant detection + consensus.
-hostremove_reference: '/home/kmsmith/data/MN908947_3.fasta'
+# Used as -r,-g arguments to 'quast'
+viral_reference_genome: '/home/kmsmith/data/MN908947_3.fasta'
+viral_reference_feature_coords: '/home/kmsmith/data/MN908947_3.gff3'
 
 # Used as --reference argument to 'breseq'
 breseq_reference: '/home/kmsmith/data/MN908947_primer_annotated_prot_clinical.gb'
@@ -38,9 +40,6 @@ lmat_fragment_size: 250
 lmat_basedir: '/home/kmsmith/data/LMAT-1.2.6'
 lmat_db: 'kML+Human.v4-14.20.g10.db'
 
-# Used as -r,-g arguments to 'quast'
-quast_reference_genome: '/home/kmsmith/data/MN908947_3.fasta'
-quast_feature_coords: '/home/kmsmith/data/MN908947_3.gff3'
 
 # List of samples to be analyzed follows.
 # Dictionary is keyed by sample name (=directory name).


### PR DESCRIPTION
- Compressed the reference genome for quast, consensus, and host removal to a single param
- Added a json schema and validation of the `config.yaml` (the sample validation still needs work but I think I'm going to make this a table which we can generate with @kmsmith137's python script) 